### PR TITLE
Make it possible to edit the props of 'form' through Site Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Make it possible to edit the props of `form` through Site Editor.
 
 ## [0.3.5] - 2020-05-13
 ### Added

--- a/messages/context.json
+++ b/messages/context.json
@@ -1,4 +1,7 @@
 {
+  "admin/editor.form.title": "Form",
+  "admin/editor.form.entity.title": "Entity",
+  "admin/editor.form.schema.title": "Schema",
   "store/form.error.required": "This field is required",
   "store/form.error.maxLength": "This field has a max length of: {value}",
   "store/form.error.minLength": "This field has a min length of: {value}",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,4 +1,7 @@
 {
+  "admin/editor.form.title": "Form",
+  "admin/editor.form.entity.title": "Entity",
+  "admin/editor.form.schema.title": "Schema",
   "store/form.error.required": "This field is required",
   "store/form.error.maxLength": "This field has a max length of: {value}",
   "store/form.error.minLength": "This field has a min length of: {value}",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,4 +1,7 @@
 {
+  "admin/editor.form.title": "Formulario",
+  "admin/editor.form.entity.title": "Entidad",
+  "admin/editor.form.schema.title": "Schema",
   "store/form.error.required": "Este campo es requerido",
   "store/form.error.maxLength": "Este campo tiene una longitud máxima de: {value}",
   "store/form.error.minLength": "Este campo tiene una longitud mínima de: {value}",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,4 +1,7 @@
 {
+  "admin/editor.form.title": "Formulário",
+  "admin/editor.form.entity.title": "Entidade",
+  "admin/editor.form.schema.title": "Schema",
   "store/form.error.required": "Este campo é necessário",
   "store/form.error.maxLength": "Este campo deve ter até {value} caracteres",
   "store/form.error.minLength": "Este campo deve ter no mínimo {value} caracteres",

--- a/react/Form.tsx
+++ b/react/Form.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React from 'react'
 import { useQuery } from 'react-apollo'
 import { useIntl, defineMessages } from 'react-intl'
 import { Alert } from 'vtex.styleguide'
@@ -20,7 +20,7 @@ const messages = defineMessages({
   },
 })
 
-const Form: FC<FormProps> = props => {
+const Form: SFC<FormProps> = props => {
   const { entity, schema, children } = props
   const intl = useIntl()
   const { data, loading, error } = useQuery(documentPublicSchema, {
@@ -60,6 +60,10 @@ const Form: FC<FormProps> = props => {
       {children}
     </FormHandler>
   )
+}
+
+Form.schema = {
+  title: 'admin/editor.form.title',
 }
 
 export default Form

--- a/react/typings/site-editor.d.ts
+++ b/react/typings/site-editor.d.ts
@@ -1,0 +1,8 @@
+import { FunctionComponent, ReactElement } from 'react'
+
+declare global {
+  interface SFC<P = {}> extends FunctionComponent<P> {
+    getSchema?(props: P): object
+    schema?: object
+  }
+}

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -2,7 +2,21 @@
   "form": {
     "component": "Form",
     "composition": "children",
-    "allowed": ["form-success"]
+    "allowed": ["form-success"],
+    "content": {
+      "title": "admin/editor.form.title",
+      "type": "object",
+      "properties": {
+        "entity": {
+          "title": "admin/editor.form.entity.title",
+          "type": "string"
+        },
+        "schema": {
+          "title": "admin/editor.form.schema.title",
+          "type": "string"
+        }
+      }
+    }
   },
   "form-field-group": {
     "component": "FormFieldGroup"


### PR DESCRIPTION
#### What does this PR do? \*

Make it possible to change the entity and schema of a form using the Site Editor.

This enables the change the schema of the form based on the binding, making it translatable.

#### How to test it? \*

https://brenovtex--unileverb2b.myvtex.com/admin/app/cms/site-editor

![image](https://user-images.githubusercontent.com/284515/83900879-571cde80-a730-11ea-8831-c0cf6a15f611.png)

#### Describe alternatives you've considered, if any. \*

n/a

#### Related to / Depends on \*

n/a
