### PR TITLE
Fix textarea label

### DIFF
--- a/react/components/TextArea.tsx
+++ b/react/components/TextArea.tsx
@@ -1,24 +1,28 @@
 import React, { FC } from 'react'
+import { BaseInputProps } from '../typings/InputProps'
 import { Textarea as StyleguideTextarea } from 'vtex.styleguide'
 import { UseTextAreaReturnType, useTextArea } from 'react-hook-form-jsonschema'
 
 import { useFormattedError } from '../hooks/useErrorMessage'
 
-export const TextAreaInput: FC<{ pointer: string }> = props => {
+export const TextAreaInput: FC<BaseInputProps> = props => {
   const textAreaObject = useTextArea(props.pointer)
-  return <TextArea textAreaObject={textAreaObject} />
+  return <TextArea textAreaObject={textAreaObject} label={props.label} />
 }
 
 export const TextArea: FC<{
-  textAreaObject: UseTextAreaReturnType
+  textAreaObject: UseTextAreaReturnType,
+  label?: string
 }> = props => {
   const { textAreaObject } = props
   const error = textAreaObject.getError()
+  const subSchema = textAreaObject.getObject()
+  const label = props.label ?? subSchema.title ?? textAreaObject.name
 
   return (
     <StyleguideTextarea
       {...textAreaObject.getTextAreaProps()}
-      label={textAreaObject.getObject().title}
+      label={label}
       error={!!error}
       errorMessage={useFormattedError(error)}
     />


### PR DESCRIPTION
#### What problem is this solving?

The textarea wasn't accepting the label prop

#### How to test it?

Create a form, define a textarea field and use the "label" prop

[beta](https://beta--fstudio.myvtex.com/contact)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/42587916/90560490-de161a80-e1a7-11ea-9ccd-d9eb6d792787.png)

![image](https://user-images.githubusercontent.com/42587916/90560542-f0905400-e1a7-11ea-8a43-49bcbf74a118.png)


#### How does this PR make you feel? 

![](https://gph.is/g/EJAjkN4)
