### PR TITLE
Trigger some warnings if the MasterData schema is wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Handle common errors in MasterData schemas.
 
 ## [0.3.6] - 2020-08-19
 ### Fixed

--- a/react/Form.tsx
+++ b/react/Form.tsx
@@ -46,6 +46,27 @@ const Form: FC<FormProps> = props => {
 
   const schemaDocument = data.documentPublicSchema.schema
 
+  if (!schemaDocument) {
+    console.error('No MasterData Schema found')
+    return null
+  }
+
+  if (!('properties' in schemaDocument)) {
+    console.error(
+      `The MasterData Schema fields should be inside "properties". Example: { "schema": { "type": "object", "properties": { "foo": { "type": "string" } }}}`
+    )
+    console.error('Received:', schemaDocument)
+    return null
+  }
+
+  if (!('type' in schemaDocument)) {
+    console.error(
+      `The MasterData Schema is missing the required property \`"type": "object"\`. Example: { "schema": { "type": "object", "properties": { "foo": { "type": "string" } }}}`
+    )
+    console.error('Received:', schemaDocument)
+    return null
+  }
+
   if (!React.Children.count(children)) {
     return (
       <FormHandler schema={schemaDocument} formProps={props}>

--- a/react/__tests__/Form.test.tsx
+++ b/react/__tests__/Form.test.tsx
@@ -93,5 +93,31 @@ describe('Form', () => {
     )
     expect(errorSpy.mock.calls[1][0]).toBe(`Received:`)
     expect(errorSpy.mock.calls[1][1]).toBe(schema)
+
+    errorSpy.mockReset()
+  })
+
+  it('should render OK if all required fields are present', () => {
+    const schema = {
+      type: 'object',
+      properties: { firstName: { type: 'string' } },
+    }
+    jest.spyOn(Apollo, 'useQuery').mockImplementation((query, options) => ({
+      data: {
+        documentPublicSchema: {
+          schema,
+        },
+      },
+      query,
+      options,
+    }))
+
+    const { getAllByText } = render(
+      <Form entity="foo" schema="bar">
+        <FormText pointer="#/properties/firstName" />
+      </Form>
+    )
+
+    expect(getAllByText('firstName')[0]).toBeDefined()
   })
 })


### PR DESCRIPTION
#### What problem is this solving?

Avoid exploding if the Masterdata schema is in the wrong format and give some tips on how to fix it.

This was motivated after this Slack thread: https://vtex.slack.com/archives/C9P4RMW6Q/p1600964679005000

1. It warns if the schema doesn't have the `properties` field
2. It warns if the schema doesn't have the `"type": "object"` defined in the root

If one of those two are missing it used to explode

#### How to test it?

I added unit tests.

Also it's linked in this workspace without triggering errors:
https://formulario--eduardofuentes.myvtex.com/cetaphil-locion-limpiadora-piel-sensible-473-ml/p?__disableSSR

#### Describe alternatives you've considered, if any.

N/a

#### Related to / Depends on

n/a

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/fceh5CXz9mjHa/source.gif)
