### PR TITLE
Feature/placeholder prop inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Prop `placeholder` for text and textarea inputs.
 
 ## [0.3.9] - 2020-10-30
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -151,7 +151,7 @@ In the example below, the form block is contained in a Flex Layout row:
 
 | Prop name   | Type                                 | Description                                                                                                                                                                                                                                      | Default Value |
 | ----------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `placeholderText`   | `string`    |  Placeholder text for the textarea input.	 | `undefined`              |
+| `placeholder`   | `string`    |  Placeholder for the textarea input.	 | `undefined`              |
 
 ### `form-input.text` props
 
@@ -160,7 +160,7 @@ In the example below, the form block is contained in a Flex Layout row:
 | `pointer`   | `string`    | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) JSON schema pointer i.e. the JSON schema path  (for example: #/properties/firstName) in which the form block inputs should be validated against. | `undefined`              |
 | `inputType` | `enum` | Defines which type of a text field should be rendered: <br>`input`: renders a normal text field.<br>`hidden`: does not render any text field. It should be used in scenarios in which you want to pre-define a field value to be submitted to the form but that shouldn't be visible (and therefore editable) to users. <br>`password`: renders a password text field.                 | `input`           |
 | `label` | `string` |  ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Field's name when rendered | Property's title  |
-| `placeholderText`   | `string`    |  Placeholder text for the text input.	 | `undefined`              |
+| `placeholder`   | `string`    |  Placeholder for the text input.	 | `undefined`              |
 
 ### `form-field-group` props
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -147,6 +147,12 @@ In the example below, the form block is contained in a Flex Layout row:
 | `pointer` | `string` |  ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red)  JSON schema pointer i.e. the JSON schema path  (for example: #/properties/firstName) in which the form block inputs should be validated against. | `undefined`              |
 | `label` | `string` |  ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Field's name when rendered | Property's title  |
 
+### `form-input.textarea` props
+
+| Prop name   | Type                                 | Description                                                                                                                                                                                                                                      | Default Value |
+| ----------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `placeholderText`   | `string`    |  Placeholder text for the textarea input.	 | `undefined`              |
+
 ### `form-input.text` props
 
 | Prop name   | Type                                 | Description                                                                                                                                                                                                                                      | Default Value |
@@ -154,6 +160,7 @@ In the example below, the form block is contained in a Flex Layout row:
 | `pointer`   | `string`    | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) JSON schema pointer i.e. the JSON schema path  (for example: #/properties/firstName) in which the form block inputs should be validated against. | `undefined`              |
 | `inputType` | `enum` | Defines which type of a text field should be rendered: <br>`input`: renders a normal text field.<br>`hidden`: does not render any text field. It should be used in scenarios in which you want to pre-define a field value to be submitted to the form but that shouldn't be visible (and therefore editable) to users. <br>`password`: renders a password text field.                 | `input`           |
 | `label` | `string` |  ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Field's name when rendered | Property's title  |
+| `placeholderText`   | `string`    |  Placeholder text for the text input.	 | `undefined`              |
 
 ### `form-field-group` props
 

--- a/react/__mocks__/vtex.native-types.js
+++ b/react/__mocks__/vtex.native-types.js
@@ -1,5 +1,0 @@
-import React, { FC } from 'react'
-
-export const IOMessage = props => {
-  return <p>props.id</p>
-}

--- a/react/__mocks__/vtex.native-types.jsx
+++ b/react/__mocks__/vtex.native-types.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export const IOMessage = props => {
+  return <p>{props.id}</p>
+}
+
+export function formatIoMessage(params) {
+  return params.id
+}

--- a/react/components/Input.tsx
+++ b/react/components/Input.tsx
@@ -6,8 +6,6 @@ import {
   usePassword,
   useHidden,
 } from 'react-hook-form-jsonschema'
-import { useIntl } from 'react-intl'
-import { formatIOMessage } from 'vtex.native-types'
 
 import { useFormattedError } from '../hooks/useErrorMessage'
 import { FormRawInputProps } from '../typings/InputProps'
@@ -39,7 +37,6 @@ export const Input: FC<{
 }> = props => {
   const { inputObject, placeholder } = props
   const error = inputObject.getError()
-  const intl = useIntl()
 
   const subSchema = inputObject.getObject()
   const label = props.label ?? subSchema.title ?? inputObject.name
@@ -50,7 +47,7 @@ export const Input: FC<{
       label={label}
       error={!!error}
       errorMessage={useFormattedError(error)}
-      placeholder={formatIOMessage({ id: placeholder, intl })}
+      placeholder={placeholder}
     />
   )
 }

--- a/react/components/Input.tsx
+++ b/react/components/Input.tsx
@@ -17,9 +17,11 @@ export const HiddenInput: FC<FormRawInputProps> = props => {
 }
 
 export const PasswordInput: FC<FormRawInputProps> = props => {
-  const { pointer, label } = props
+  const { pointer, label, placeholder } = props
   const inputObject = usePassword(pointer)
-  return <Input inputObject={inputObject} label={label} />
+  return (
+    <Input inputObject={inputObject} label={label} placeholder={placeholder} />
+  )
 }
 
 export const RawInput: FC<FormRawInputProps> = props => {

--- a/react/components/Input.tsx
+++ b/react/components/Input.tsx
@@ -6,6 +6,8 @@ import {
   usePassword,
   useHidden,
 } from 'react-hook-form-jsonschema'
+import { useIntl } from 'react-intl'
+import { formatIOMessage } from 'vtex.native-types'
 
 import { useFormattedError } from '../hooks/useErrorMessage'
 import { FormRawInputProps } from '../typings/InputProps'
@@ -23,17 +25,25 @@ export const PasswordInput: FC<FormRawInputProps> = props => {
 }
 
 export const RawInput: FC<FormRawInputProps> = props => {
-  const { pointer, label } = props
+  const { pointer, label, placeholderText } = props
   const inputObject = useInput(pointer)
-  return <Input inputObject={inputObject} label={label} />
+  return (
+    <Input
+      inputObject={inputObject}
+      label={label}
+      placeholderText={placeholderText}
+    />
+  )
 }
 
 export const Input: FC<{
   inputObject: UseRawInputReturnType
   label?: string
+  placeholderText?: string
 }> = props => {
-  const { inputObject } = props
+  const { inputObject, placeholderText } = props
   const error = inputObject.getError()
+  const intl = useIntl()
 
   const subSchema = inputObject.getObject()
   const label = props.label ?? subSchema.title ?? inputObject.name
@@ -44,6 +54,7 @@ export const Input: FC<{
       label={label}
       error={!!error}
       errorMessage={useFormattedError(error)}
+      placeholder={formatIOMessage({ id: placeholderText, intl })}
     />
   )
 }

--- a/react/components/Input.tsx
+++ b/react/components/Input.tsx
@@ -25,23 +25,19 @@ export const PasswordInput: FC<FormRawInputProps> = props => {
 }
 
 export const RawInput: FC<FormRawInputProps> = props => {
-  const { pointer, label, placeholderText } = props
+  const { pointer, label, placeholder } = props
   const inputObject = useInput(pointer)
   return (
-    <Input
-      inputObject={inputObject}
-      label={label}
-      placeholderText={placeholderText}
-    />
+    <Input inputObject={inputObject} label={label} placeholder={placeholder} />
   )
 }
 
 export const Input: FC<{
   inputObject: UseRawInputReturnType
   label?: string
-  placeholderText?: string
+  placeholder?: string
 }> = props => {
-  const { inputObject, placeholderText } = props
+  const { inputObject, placeholder } = props
   const error = inputObject.getError()
   const intl = useIntl()
 
@@ -54,7 +50,7 @@ export const Input: FC<{
       label={label}
       error={!!error}
       errorMessage={useFormattedError(error)}
-      placeholder={formatIOMessage({ id: placeholderText, intl })}
+      placeholder={formatIOMessage({ id: placeholder, intl })}
     />
   )
 }

--- a/react/components/TextArea.tsx
+++ b/react/components/TextArea.tsx
@@ -7,14 +7,21 @@ import { useFormattedError } from '../hooks/useErrorMessage'
 
 export const TextAreaInput: FC<BaseInputProps> = props => {
   const textAreaObject = useTextArea(props.pointer)
-  return <TextArea textAreaObject={textAreaObject} label={props.label} />
+  return (
+    <TextArea
+      textAreaObject={textAreaObject}
+      label={props.label}
+      placeholderText={props.placeholderText}
+    />
+  )
 }
 
 export const TextArea: FC<{
   textAreaObject: UseTextAreaReturnType
   label?: string
+  placeholderText?: string
 }> = props => {
-  const { textAreaObject } = props
+  const { textAreaObject, placeholderText } = props
   const error = textAreaObject.getError()
   const subSchema = textAreaObject.getObject()
   const label = props.label ?? subSchema.title ?? textAreaObject.name
@@ -25,6 +32,7 @@ export const TextArea: FC<{
       label={label}
       error={!!error}
       errorMessage={useFormattedError(error)}
+      placeholder={placeholderText}
     />
   )
 }

--- a/react/components/TextArea.tsx
+++ b/react/components/TextArea.tsx
@@ -11,7 +11,7 @@ export const TextAreaInput: FC<BaseInputProps> = props => {
     <TextArea
       textAreaObject={textAreaObject}
       label={props.label}
-      placeholderText={props.placeholderText}
+      placeholder={props.placeholder}
     />
   )
 }
@@ -19,9 +19,9 @@ export const TextAreaInput: FC<BaseInputProps> = props => {
 export const TextArea: FC<{
   textAreaObject: UseTextAreaReturnType
   label?: string
-  placeholderText?: string
+  placeholder?: string
 }> = props => {
-  const { textAreaObject, placeholderText } = props
+  const { textAreaObject, placeholder } = props
   const error = textAreaObject.getError()
   const subSchema = textAreaObject.getObject()
   const label = props.label ?? subSchema.title ?? textAreaObject.name
@@ -32,7 +32,7 @@ export const TextArea: FC<{
       label={label}
       error={!!error}
       errorMessage={useFormattedError(error)}
-      placeholder={placeholderText}
+      placeholder={placeholder}
     />
   )
 }

--- a/react/typings/InputProps.ts
+++ b/react/typings/InputProps.ts
@@ -3,6 +3,7 @@ import { UISchemaType } from 'react-hook-form-jsonschema'
 export interface BaseInputProps {
   pointer: string
   label?: string
+  placeholderText?: string
 }
 
 export interface FormFieldGroupProps extends Omit<BaseInputProps, 'label'> {

--- a/react/typings/InputProps.ts
+++ b/react/typings/InputProps.ts
@@ -3,7 +3,7 @@ import { UISchemaType } from 'react-hook-form-jsonschema'
 export interface BaseInputProps {
   pointer: string
   label?: string
-  placeholderText?: string
+  placeholder?: string
 }
 
 export interface FormFieldGroupProps extends Omit<BaseInputProps, 'label'> {


### PR DESCRIPTION
#### What problem is this solving?

Currently, the store-form component does not have an option to add a placeholder to inputs

#### How to test it?

1. Enter the workspace and scroll until reach the form
2. According to the value passed in the placeholderText property, the placeholder will be displayed in the input

[Workspace](https://will--mundopet.myvtex.com/osso-mastig-natural-femur-suino-para-caes/p?skuId=757)

#### Screenshots or example usage:

https://prnt.sc/vhk3fr