### PR TITLE
Change form-input.upload to render only on client to avoid breaking SSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Change `form-input.upload` to render only on client since it breaks SSR.
 
 ## [0.5.0] - 2021-02-12
 

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -26,7 +26,8 @@
     "component": "FormInputTextArea"
   },
   "form-input.upload": {
-    "component": "FormInputUpload"
+    "component": "FormInputUpload",
+    "render": "client"
   },
   "form-submit": {
     "component": "FormSubmit"


### PR DESCRIPTION
#### What problem is this solving?

The block `form-input.upload` is breaking in SSR because of the component Tooltip from the styleguide.

![image](https://user-images.githubusercontent.com/284515/111490499-d6a4f880-8719-11eb-9b7f-8fccb680ab03.png)

#### How to test it?

Current behavior:
https://formupload--storecomponents.myvtex.com/contact-us

Fix:
https://breno--storecomponents.myvtex.com/contact-us

#### Screenshots or example usage:

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
