### PR TITLE
Add placeholder props in Dropdown component

### DIFF
--- a/react/components/Dropdown.tsx
+++ b/react/components/Dropdown.tsx
@@ -17,12 +17,14 @@ export const DropdownInput: FC<BaseInputProps> = props => {
 export const Dropdown: FC<{
   selectObject: UseSelectReturnType
   label?: string
+  placeholder?: string
 }> = props => {
   const { selectObject } = props
   const error = selectObject.getError()
 
   const subSchema = selectObject.getObject()
   const label = props.label ?? subSchema.title ?? selectObject.name
+  const placeholder = props.placeholder || label
 
   const items = selectObject.getItems()
   const options = useMemo(() => {
@@ -45,6 +47,7 @@ export const Dropdown: FC<{
             options={options}
             error={!!error}
             errorMessage={useFormattedError(error)}
+            placeholder={placeholder}
           />
         }
       />


### PR DESCRIPTION
#### What problem is this solving?

We need to add in a placeholder props to customise the placeholder being shown in the select area of the dropdown component in the store form. Currently the placeholder is the label props. I referred my proposed changes to this: https://styleguide.vtex.com/#/Components/Forms/Dropdown